### PR TITLE
Fix for hostname styling 

### DIFF
--- a/ies-datadog/spec/default_spec.rb
+++ b/ies-datadog/spec/default_spec.rb
@@ -28,7 +28,7 @@ describe 'ies-datadog::default' do
 
       expected = [
         'api_key: 40404040404040404040404040404040',
-        'hostname: playground.chefspec_lb'
+        'hostname: playground-chefspec_lb'
       ]
 
       expected.each do |content|

--- a/ies-datadog/spec/haproxy_spec.rb
+++ b/ies-datadog/spec/haproxy_spec.rb
@@ -34,7 +34,7 @@ describe 'ies-datadog::default' do
 
       expected = [
         'api_key: 40404040404040404040404040404040',
-        'hostname: playground.chefspec_lb'
+        'hostname: playground-chefspec_lb'
       ]
 
       expected.each do |content|

--- a/ies-datadog/templates/default/datadog.conf.erb
+++ b/ies-datadog/templates/default/datadog.conf.erb
@@ -1,7 +1,7 @@
 [Main]
 dd_url: https://app.datadoghq.com
 api_key: <%= @datadog_api_key %>
-hostname: <%= @stack_name %>.<%= @host_name %>
+hostname: <%= @stack_name %>-<%= @host_name %>
 gce_updated_hostname: yes
 non_local_traffic: no
 use_dogstatsd: no


### PR DESCRIPTION
# Changes

_Datadog_ doesn't like . in host names.  This was a simple oversight.  I updated the template and the spec tests.  Probably should include a `.gsub` at some point but in general this should work fo rthe time being.

# CR

 - _(if applicable) how to test them_
 - please update the stable PR post-merge

Related: #issue
