### PR TITLE
try setting ppa for php5.6-apcu

### DIFF
--- a/php/attributes/default.rb
+++ b/php/attributes/default.rb
@@ -11,6 +11,8 @@ default['php-aws-elasticache']['settings'] = {}
 
 default['php-apc'] = {}
 # custom prefix for package: php-apcu, instead of php5.6-apcu
+default['php-apc']['package_uri'] = 'ppa:ondrej/php'
+default['php-apc']['package_distro'] = 'trusty'
 default['php-apc']['package_prefix'] = nil
 default['php-apc']['settings']['ttl'] = 0
 default['php-apc']['settings']['mmap_file_mask'] = '/dev/zero'


### PR DESCRIPTION
# Changes

trying to fix:
    package[php5.6-apcu] (php-fpm::default line 40) had an error: Chef::Exceptions::Package: No version specified, and no candidate version available for php5.6-apcu